### PR TITLE
Isilon Total Size less overhead

### DIFF
--- a/lib/isilon_api/report.rb
+++ b/lib/isilon_api/report.rb
@@ -6,7 +6,7 @@ require 'isilon_api'
 module IsilonApi
   module Report
 
-    @@isilon_total_size = 313723602432 * 1024 
+    @@isilon_total_size = 313723602432 * 1024 * 2 / 3
     @@default_scale_factor = 1.0E+6
     @@units_table={'mb' => 1.0E+6,
                    'gb' => 1.0E+9,
@@ -44,8 +44,8 @@ module IsilonApi
         "free (#{@units})",
         "soft quota (#{@units})",
         "hard quota (#{@units})",
-        "percentage used",
-        "hard limit (%)"
+        "percentage of hard limit used",
+        "percentage of Isilon used"
       ]
       csv_file << quotas_header
     end

--- a/spec/quota/report_spec.rb
+++ b/spec/quota/report_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe IsilonApi::Report do
     before do
       raw = JSON.load(open(File.join(SPEC_ROOT, 'fixtures', 'single_quota.json')))
       @quota = IsilonApi::Quota.new :quota => raw
-      allow(@quota).to receive(:isilon_total_size) { 313723602432 * 1024 }
+      allow(@quota).to receive(:isilon_total_size) { 313723602432 * 1024 * 2 / 3 }
     end
 
     it 'displays quota array' do


### PR DESCRIPTION
- Isilon uses 1/3 for overhead. Total available size is 2/3 of that
  total Isilon size.
- Provide more meaningful percentage used report headers.